### PR TITLE
Downgrade ganache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: pip install eth-brownie
-      - run: npm install -g ganache
+      - run: pip install eth-brownie anyio
+      - run: npm install -g ganache@7.6.0
       # - run: ganache
       - run: brownie pm install OpenZeppelin/openzeppelin-contracts@4.8.0
       - run: brownie compile


### PR DESCRIPTION
This bug seems to be caused by an update in `ganache` that `eth-brownie` doesn't support.
This bug is tracked at [ #1644](https://github.com/eth-brownie/brownie/issues/1644#issue-1500318877)